### PR TITLE
Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/PaperMod"]
+	path = themes/PaperMod
+	url = https://github.com/JrPatt275/hugo-PaperMod.git

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,10 +2,7 @@ baseURL: "https://jpcloud.tech/"
 title: JP Cloud Tech
 pagination.pagerSize: 5
 
-module:
-  imports:
-    - path: github.com/adityatelange/hugo-PaperMod
-
+theme: ["PaperMod"]
 
 enableRobotsTXT: true
 buildDrafts: false


### PR DESCRIPTION
This pull request updates the theme configuration for the Hugo site by switching to a local submodule for the PaperMod theme instead of importing it remotely. The main changes involve adding the PaperMod theme as a git submodule and updating the site configuration to use this local theme.

Theme management updates:

* Added the PaperMod theme as a git submodule in the `.gitmodules` file, referencing the repository at `https://github.com/JrPatt275/hugo-PaperMod.git`.
* Updated the `themes/PaperMod` directory to point to the new submodule commit.

Configuration changes:

* Modified `hugo.yaml` to use the local PaperMod theme via the `theme` key, and removed the previous `module.imports` configuration for the remote theme.